### PR TITLE
Refine chat message metadata and reactions

### DIFF
--- a/chat/chat.css
+++ b/chat/chat.css
@@ -188,20 +188,23 @@ dialog { position:relative; width:min(100% - 2rem,32rem); padding:2rem; color:va
 
 .message-footer {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: flex-end;
-  gap: 6px;
+  gap: 4px;
+  margin-top: 4px;
 }
 
-.timeline-time {
-  margin-top: 4px;
+.message-footer .timeline-time {
+  margin: 0;
   font-size: 11px;
 }
 
 .message-delete {
-  width: 28px;
-  height: 28px;
-  font-size: 13px;
+  width: 24px;
+  height: 24px;
+  border-color: transparent;
+  background: transparent;
+  font-size: 12px;
 }
 
 .message-reactions {

--- a/chat/chat.css
+++ b/chat/chat.css
@@ -146,6 +146,35 @@ dialog { position:relative; width:min(100% - 2rem,32rem); padding:2rem; color:va
   gap: 8px;
 }
 
+.timeline-wrap {
+  position: relative;
+  display: flex;
+  min-height: 0;
+  flex: 1;
+}
+
+.timeline-wrap .timeline {
+  flex: 1;
+}
+
+.timeline-wrap .timeline-status {
+  position: absolute;
+  top: 7px;
+  left: 50%;
+  z-index: 2;
+  width: max-content;
+  max-width: calc(100% - 20px);
+  padding: 4px 9px;
+  background: rgba(245, 247, 246, .94);
+  border: 1px solid #d7e3df;
+  border-radius: 999px;
+  box-shadow: 0 2px 8px rgba(35, 71, 63, .1);
+  font-size: 12px;
+  text-align: center;
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
 .timeline-message {
   align-items: flex-end;
   gap: 7px;
@@ -232,12 +261,38 @@ dialog { position:relative; width:min(100% - 2rem,32rem); padding:2rem; color:va
 .message-reaction-add {
   min-width: 28px;
   padding-inline: 6px;
+  color: #52756d;
+  background: transparent;
+  border-style: dashed;
+}
+
+.message-reaction:hover,
+.message-reaction:focus-visible {
+  background: #d4e9e3;
+  border-color: #91beb3;
+}
+
+.message-reaction.mine {
+  color: #fff;
+  background: #2f8876;
+  border-color: #2f8876;
 }
 
 .reaction-picker {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 3;
   display: flex;
+  width: max-content;
+  max-width: 156px;
   flex-wrap: wrap;
-  gap: 3px;
+  gap: 4px;
+  padding: 6px;
+  background: #fff;
+  border: 1px solid #c7ddd7;
+  border-radius: 10px;
+  box-shadow: 0 5px 18px rgba(35, 71, 63, .18);
 }
 
 .reaction-picker[hidden] {
@@ -245,8 +300,16 @@ dialog { position:relative; width:min(100% - 2rem,32rem); padding:2rem; color:va
 }
 
 .reaction-picker button {
-  min-width: 30px;
-  padding-inline: 4px;
+  min-width: 32px;
+  padding: 3px 5px;
+  background: #f4f8f6;
+  border-color: transparent;
+  font-size: 16px;
+}
+
+.reaction-picker button:hover,
+.reaction-picker button:focus-visible {
+  background: #e0efeb;
 }
 
 .room-readonly {

--- a/chat/chat.js
+++ b/chat/chat.js
@@ -51,6 +51,11 @@ import { hexToNpub, parseNip05Identifier } from './identity.js';
 
   const normalizedSearch = () => chatFilter?.value.trim().toLocaleLowerCase() || '';
   const senderLabelFor = (message) => message.nip05 || message.sender;
+  const formatTimestamp = (timestamp) => {
+    const date = new Date(timestamp);
+    const pad = (value) => String(value).padStart(2, '0');
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+  };
   const roomMessages = (room) => {
     const byEvent = new Map();
     for (const message of [...timelines[room].older, ...timelines[room].recent]) {
@@ -246,7 +251,7 @@ import { hexToNpub, parseNip05Identifier } from './identity.js';
     const time = document.createElement('time');
     time.className = 'timeline-time';
     time.dateTime = new Date(message.timestamp).toISOString();
-    time.textContent = new Date(message.timestamp).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short' });
+    time.textContent = formatTimestamp(message.timestamp);
     const body = document.createElement('p');
     body.className = 'timeline-body';
     body.textContent = message.msgtype === 'm.emote' ? `* ${message.sender} ${message.body}` : message.body;
@@ -293,6 +298,7 @@ import { hexToNpub, parseNip05Identifier } from './identity.js';
     }
     const footer = document.createElement('div');
     footer.className = 'message-footer';
+    footer.append(time);
     if (writableRooms.has(room) && message.nip05 && activeSession?.nip05?.toLocaleLowerCase() === message.nip05.toLocaleLowerCase()) {
       const remove = document.createElement('button');
       remove.className = 'message-delete';
@@ -306,7 +312,6 @@ import { hexToNpub, parseNip05Identifier } from './identity.js';
     meta.append(sender);
     bubble.append(meta, body);
     if (reactionList.childElementCount) bubble.append(reactionList);
-    footer.append(time);
     bubble.append(footer);
     item.append(avatar, bubble);
     return item;

--- a/chat/chat.js
+++ b/chat/chat.js
@@ -225,8 +225,16 @@ import { hexToNpub, parseNip05Identifier } from './identity.js';
       });
       await loadTimeline({ room, silent: true });
     } catch (error) {
-      composerStatus.textContent = error.message || 'Reaction could not be added.';
+      composerStatus.textContent = error.message || 'Reaction could not be changed.';
       button.disabled = false;
+    }
+  };
+
+  const closeReactionPickers = (except = null) => {
+    for (const picker of document.querySelectorAll('.reaction-picker:not([hidden])')) {
+      if (picker === except) continue;
+      picker.hidden = true;
+      picker.parentElement?.querySelector('.message-reaction-add')?.setAttribute('aria-expanded', 'false');
     }
   };
 
@@ -265,7 +273,10 @@ import { hexToNpub, parseNip05Identifier } from './identity.js';
       reactionPill.textContent = `${reaction.key} ${reaction.count}`;
       if (reactionPill instanceof HTMLButtonElement) {
         reactionPill.type = 'button';
-        reactionPill.title = `Add ${reaction.key} reaction`;
+        reactionPill.classList.toggle('mine', reaction.mine === true);
+        reactionPill.setAttribute('aria-pressed', String(reaction.mine === true));
+        reactionPill.title = reaction.mine ? `Remove your ${reaction.key} reaction` : `Add ${reaction.key} reaction`;
+        reactionPill.setAttribute('aria-label', reactionPill.title);
         reactionPill.addEventListener('click', () => reactToMessage(message, room, reaction.key, reactionPill));
       }
       reactionList.append(reactionPill);
@@ -280,18 +291,24 @@ import { hexToNpub, parseNip05Identifier } from './identity.js';
         choice.textContent = key;
         choice.title = `React with ${key}`;
         choice.setAttribute('aria-label', `React with ${key}`);
-        choice.addEventListener('click', () => reactToMessage(message, room, key, choice));
+        choice.addEventListener('click', () => {
+          picker.hidden = true;
+          addReaction.setAttribute('aria-expanded', 'false');
+          reactToMessage(message, room, key, choice);
+        });
         picker.append(choice);
       }
       const addReaction = document.createElement('button');
       addReaction.className = 'message-reaction-add';
       addReaction.type = 'button';
-      addReaction.textContent = '+';
+      addReaction.textContent = '＋';
       addReaction.title = 'Add a reaction';
       addReaction.setAttribute('aria-label', 'Add a reaction');
       addReaction.setAttribute('aria-expanded', 'false');
       addReaction.addEventListener('click', () => {
-        picker.hidden = !picker.hidden;
+        const opening = picker.hidden;
+        closeReactionPickers(opening ? picker : null);
+        picker.hidden = !opening;
         addReaction.setAttribute('aria-expanded', String(!picker.hidden));
       });
       reactionList.append(addReaction, picker);
@@ -563,6 +580,9 @@ import { hexToNpub, parseNip05Identifier } from './identity.js';
   composer.addEventListener('submit', (event) => {
     event.preventDefault();
     sendMessage();
+  });
+  document.addEventListener('click', (event) => {
+    if (!event.target.closest('.message-reactions')) closeReactionPickers();
   });
   window.addEventListener('hashchange', () => {
     syncRoomNavigation();

--- a/chat/index.html
+++ b/chat/index.html
@@ -64,8 +64,10 @@
         <div id="room-participants" class="room-participants" aria-label="Room participants" hidden></div>
         <button id="timeline-older" class="timeline-older" type="button" hidden>Load older messages</button>
         <button id="timeline-retry" class="timeline-retry" type="button" hidden>Try again</button>
-        <p id="timeline-status" class="timeline-status" role="status" aria-live="polite">Loading messages…</p>
-        <ol id="timeline" class="timeline" aria-label="Room messages"></ol>
+        <div class="timeline-wrap">
+          <p id="timeline-status" class="timeline-status" role="status" aria-live="polite">Loading messages…</p>
+          <ol id="timeline" class="timeline" aria-label="Room messages"></ol>
+        </div>
         <p id="room-readonly" class="room-readonly" hidden><strong>#hitchat is read-only here.</strong> Follow the conversation on the web, or join through Matrix or Signal to post.</p>
         <form id="chat-composer" class="chat-composer" aria-label="Message composer">
           <textarea id="message-input" rows="1" maxlength="4000" placeholder="Type a message…" readonly aria-label="Message input"></textarea>

--- a/chat/index.html
+++ b/chat/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Hitchwiki and Trustroots member access to the Hitchhiking Matrix chat." />
     <title>Hitchhiking chat</title>
     <link rel="icon" href="/favicon.ico" sizes="any" />
-    <link rel="stylesheet" href="/chat/chat.css?v=20260817-2" />
+    <link rel="stylesheet" href="/chat/chat.css?v=20260817-3" />
     <script defer src="https://1p.hitchhiking.org/script.js" data-website-id="166e3735-3228-4608-b43a-92761a55499e"></script>
   </head>
   <body class="chat-page">
@@ -79,6 +79,6 @@
     </div>
 
     <script type="module" src="/assets/nostr-identity.js?v=20260808-7"></script>
-    <script type="module" src="/chat/chat.js?v=20260817-2"></script>
+    <script type="module" src="/chat/chat.js?v=20260817-3"></script>
   </body>
 </html>

--- a/test/chat-page.test.js
+++ b/test/chat-page.test.js
@@ -69,6 +69,11 @@ describe('authenticated Hitchat timeline', () => {
     expect(script).toContain('reactionPill.textContent = `${reaction.key} ${reaction.count}`');
     expect(script).toContain("requestJSON('/chat/auth/chat/react'");
     expect(script).toContain("for (const key of ['👍', '❤️', '😂', '🎉', '👀', '🙏'])");
+    expect(script).toContain("reactionPill.classList.toggle('mine', reaction.mine === true)");
+    expect(script).toContain('reaction.mine ? `Remove your ${reaction.key} reaction`');
+    expect(script).toContain('closeReactionPickers(opening ? picker : null)');
+    expect(styles).toMatch(/\.reaction-picker \{[\s\S]*?position: absolute/);
+    expect(styles).toContain('.message-reaction.mine');
     expect(styles).toContain('.message-reaction');
     expect(script).not.toContain('innerHTML');
   });
@@ -130,6 +135,12 @@ describe('authenticated Hitchat timeline', () => {
   it('uses a stable compact timestamp format', () => {
     expect(script).toContain("return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`");
     expect(script).toContain('time.textContent = formatTimestamp(message.timestamp)');
+  });
+
+  it('shows timeline status without shifting messages', () => {
+    expect(page).toContain('<div class="timeline-wrap">');
+    expect(styles).toMatch(/\.timeline-wrap \.timeline-status \{[\s\S]*?position: absolute/);
+    expect(styles).toMatch(/\.timeline-wrap \{[\s\S]*?flex: 1/);
   });
 
   it('focuses the composer only when an authenticated room is writable', () => {

--- a/test/chat-page.test.js
+++ b/test/chat-page.test.js
@@ -123,6 +123,13 @@ describe('authenticated Hitchat timeline', () => {
     expect(script).toContain('JSON.stringify({ room, event_id: message.event_id })');
     expect(script).toContain("remove.textContent = '🗑'");
     expect(script).toContain("remove.setAttribute('aria-label', 'Delete your message')");
+    expect(script.indexOf('footer.append(time)')).toBeLessThan(script.indexOf('footer.append(remove)'));
+    expect(styles).toContain('.message-footer .timeline-time');
+  });
+
+  it('uses a stable compact timestamp format', () => {
+    expect(script).toContain("return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`");
+    expect(script).toContain('time.textContent = formatTimestamp(message.timestamp)');
   });
 
   it('focuses the composer only when an authenticated room is writable', () => {

--- a/test/e2e/chat.spec.js
+++ b/test/e2e/chat.spec.js
@@ -72,10 +72,17 @@ async function installChatFixtures(page) {
     if (target) {
       target.reactions ||= [];
       const existing = target.reactions.find((reaction) => reaction.key === payload.key);
-      if (existing) existing.count += 1;
-      else target.reactions.push({ key: payload.key, count: 1 });
+      if (existing?.mine) {
+        existing.count -= 1;
+        target.reactions = target.reactions.filter((reaction) => reaction.count > 0);
+        return route.fulfill({ json: { event_id: '$reaction', active: false } });
+      }
+      if (existing) {
+        existing.count += 1;
+        existing.mine = true;
+      } else target.reactions.push({ key: payload.key, count: 1, mine: true });
     }
-    return route.fulfill({ json: { event_id: '$reaction' } });
+    return route.fulfill({ json: { event_id: '$reaction', active: true } });
   });
   return state;
 }
@@ -126,6 +133,12 @@ test('Meta is writable, supports reactions and deletion, while Test explains con
   await page.getByRole('button', { name: 'React with 👍' }).click();
   await expect.poll(() => state.reacted).toEqual([{ room: 'meta', event_id: '$meta', key: '👍' }]);
   await expect(page.getByLabel('Message reactions').getByText('👍 1')).toBeVisible();
+  await page.getByRole('button', { name: 'Remove your 👍 reaction' }).click();
+  await expect.poll(() => state.reacted).toEqual([
+    { room: 'meta', event_id: '$meta', key: '👍' },
+    { room: 'meta', event_id: '$meta', key: '👍' },
+  ]);
+  await expect(page.getByLabel('Message reactions').getByText('👍 1')).toHaveCount(0);
 
   const input = page.getByLabel('Message input');
   await input.fill('New Meta post');
@@ -150,6 +163,8 @@ test('mobile layout stays compact and avoids iPhone focus zoom', async ({ page }
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
 
   await page.getByRole('link', { name: /#meta/ }).click();
+  await page.getByRole('button', { name: 'Add a reaction' }).click();
+  await expect(page.locator('.reaction-picker')).toBeVisible();
   const sizes = await page.evaluate(() => ({
     search: parseFloat(getComputedStyle(document.querySelector('#chat-filter')).fontSize),
     input: parseFloat(getComputedStyle(document.querySelector('#message-input')).fontSize),
@@ -159,4 +174,6 @@ test('mobile layout stays compact and avoids iPhone focus zoom', async ({ page }
   expect(sizes.input).toBeGreaterThanOrEqual(16);
   expect(sizes.expiry).toBeGreaterThanOrEqual(16);
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+  await page.locator('#room-title').click();
+  await expect(page.locator('.reaction-picker')).toBeHidden();
 });


### PR DESCRIPTION
Follow-up chat polish:\n\n- formats timestamps as YYYY-MM-DD HH:mm\n- moves author-only deletion beside the timestamp\n- adds active/removable reaction pills and a compact floating emoji palette\n- prevents the loading status from shifting the message list\n- preserves compact iPhone layout and avoids horizontal overflow\n\nValidated: 33 unit/release checks and 4 Playwright scenarios.