### PR TITLE
Add desktop chat sidebar release footer

### DIFF
--- a/chat/chat.css
+++ b/chat/chat.css
@@ -62,6 +62,61 @@ dialog { position:relative; width:min(100% - 2rem,32rem); padding:2rem; color:va
   padding: 12px 10px;
 }
 
+.sidebar-footer {
+  display: flex;
+  margin: auto 6px 0;
+  padding: 10px 4px 2px;
+  align-items: center;
+  justify-content: space-between;
+  color: #708881;
+  border-top: 1px solid #dbe6e2;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0;
+  opacity: 1;
+  text-align: left;
+}
+
+.sidebar-footer > span {
+  color: #8a9d98;
+  font-size: 10px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.sidebar-footer > div {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.sidebar-footer .commit-link {
+  display: grid;
+  width: 26px;
+  height: 26px;
+  margin: 0;
+  place-items: center;
+  color: #42665e;
+  background: #eef5f2;
+  border-radius: 50%;
+}
+
+.sidebar-footer .commit-link:hover,
+.sidebar-footer .commit-link:focus-visible {
+  color: #fff;
+  background: #2f8876;
+}
+
+.sidebar-footer .commit-link svg {
+  width: 15px;
+  height: 15px;
+}
+
+.sidebar-footer time {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
 .chat-search {
   margin-bottom: 6px;
 }

--- a/chat/index.html
+++ b/chat/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Hitchwiki and Trustroots member access to the Hitchhiking Matrix chat." />
     <title>Hitchhiking chat</title>
     <link rel="icon" href="/favicon.ico" sizes="any" />
-    <link rel="stylesheet" href="/chat/chat.css?v=20260817-3" />
+    <link rel="stylesheet" href="/chat/chat.css?v=20260817-4" />
     <script defer src="https://1p.hitchhiking.org/script.js" data-website-id="166e3735-3228-4608-b43a-92761a55499e"></script>
   </head>
   <body class="chat-page">
@@ -41,7 +41,10 @@
           <a class="room-item" data-room="meta" href="/chat/#meta"><span class="room-avatar meta-avatar" aria-hidden="true">M</span><span>#meta</span><span class="room-match-count" hidden></span></a>
           <a class="room-item" data-room="test" href="/chat/#test"><span class="room-avatar test-avatar" aria-hidden="true">T</span><span>#test</span><span class="room-match-count" hidden></span></a>
         </nav>
-        <span class="sidebar-build"><time datetime="2026-08-09T15:17:00+01:00">2026-08-09 15:17</time> <a class="commit-link" href="https://github.com/Hitchwiki/hitchhiking.org" aria-label="hitchhiking.org source on GitHub"><svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82A7.65 7.65 0 0 1 8 3.29c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></a></span>
+        <footer class="sidebar-build sidebar-footer">
+          <span>latest version</span>
+          <div><time datetime="2026-08-17T17:40:00+01:00">2026-08-17 17:40</time><a class="commit-link" href="https://github.com/Hitchwiki/hitchhiking.org" aria-label="hitchhiking.org source on GitHub"><svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82A7.65 7.65 0 0 1 8 3.29c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg></a></div>
+        </footer>
       </aside>
 
     <main>
@@ -81,6 +84,6 @@
     </div>
 
     <script type="module" src="/assets/nostr-identity.js?v=20260808-7"></script>
-    <script type="module" src="/chat/chat.js?v=20260817-3"></script>
+    <script type="module" src="/chat/chat.js?v=20260817-4"></script>
   </body>
 </html>

--- a/test/chat-page.test.js
+++ b/test/chat-page.test.js
@@ -41,6 +41,14 @@ describe('authenticated Hitchat timeline', () => {
     expect(page).toContain('href="/chat/#test"');
   });
 
+  it('shows a desktop sidebar footer with source and latest version time', () => {
+    expect(page).toContain('<footer class="sidebar-build sidebar-footer">');
+    expect(page).toContain('aria-label="hitchhiking.org source on GitHub"');
+    expect(page).toContain('<time datetime="2026-08-17T17:40:00+01:00">2026-08-17 17:40</time>');
+    expect(styles).toMatch(/\.sidebar-footer \{[\s\S]*?margin: auto/);
+    expect(styles).toMatch(/@media \(max-width: 760px\)[\s\S]*?\.sidebar-build \{[\s\S]*?display: none/);
+  });
+
   it('renders Matrix-controlled sender and body values as text', () => {
     expect(script).toContain('sender.textContent = senderLabel');
     expect(script).toContain("body.textContent = message.msgtype === 'm.emote'");

--- a/test/e2e/chat.spec.js
+++ b/test/e2e/chat.spec.js
@@ -96,6 +96,8 @@ test('shows avatars, stable fallbacks, reactions, and the room policy', async ({
   await expect(page.locator('#timeline .timeline-message')).toHaveCount(3);
   await expect(page.locator('#room-participants')).toContainText('Matrix 4');
   await expect(page.locator('#room-participants')).toContainText('Signal 12');
+  await expect(page.locator('.sidebar-footer')).toContainText('2026-08-17 17:40');
+  await expect(page.getByRole('link', { name: 'hitchhiking.org source on GitHub' })).toBeVisible();
   await expect(page.getByLabel('Message reactions').getByText('👍 3')).toBeVisible();
   await expect(page.getByRole('button', { name: 'Add a reaction' })).toHaveCount(0);
   await expect(page.locator('.timeline-avatar-image')).toHaveCount(2);
@@ -159,6 +161,7 @@ test('mobile layout stays compact and avoids iPhone focus zoom', async ({ page }
   await page.goto('/chat/#hitchat');
 
   await expect(page.locator('#room-readonly')).toBeVisible();
+  await expect(page.locator('.sidebar-footer')).toBeHidden();
   await expect(page.locator('#chat-composer')).toBeHidden();
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
 


### PR DESCRIPTION
Uses the empty desktop sidebar space for a clear latest-version footer with the requested YYYY-MM-DD HH:mm timestamp and GitHub icon link. It remains hidden on mobile.\n\nValidated: 34 unit/release checks and 4 Playwright scenarios.